### PR TITLE
refactor: avoid using `import * as` syntax

### DIFF
--- a/tests/fauna/access.test.ts
+++ b/tests/fauna/access.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import { delay } from './helpers/_delay';
 import {
     destroyTestDatabase,
@@ -29,7 +28,7 @@ const setUp: SetUp = async testName => {
     context.databaseClients = await setupTestDatabase(fauna, testName);
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/dinos.fql',
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/createEmailConfirmationToken.js',

--- a/tests/fauna/changePassword.test.ts
+++ b/tests/fauna/changePassword.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     destroyTestDatabase,
     setupTestDatabase,
@@ -22,7 +21,7 @@ const setUp: SetUp = async testName => {
 
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/changePassword.js',
         'src/fauna/resources/faunauth/functions/register.js',

--- a/tests/fauna/login.test.ts
+++ b/tests/fauna/login.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import { verifyTokens } from './helpers/_test-extensions';
 import {
     destroyTestDatabase,
@@ -29,7 +28,7 @@ const setUp: SetUp = async testName => {
 
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/register.js',
         'src/fauna/resources/faunauth/functions/login.js',

--- a/tests/fauna/loginWithMagicLink.test.ts
+++ b/tests/fauna/loginWithMagicLink.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import { verifyTokens } from './helpers/_test-extensions';
 import {
     destroyTestDatabase,
@@ -30,7 +29,7 @@ const setUp: SetUp = async testName => {
 
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/createEmailConfirmationToken.js',
         'src/fauna/resources/faunauth/functions/loginWithMagicLink.js',

--- a/tests/fauna/logout.test.ts
+++ b/tests/fauna/logout.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     verifyRefreshTokensLogout,
     verifyTokens,
@@ -36,7 +35,7 @@ const setUp: SetUp = async testName => {
     const databaseClients = await setupTestDatabase(fauna, testName);
     const adminClient = databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, adminClient, [
+    await populateDatabaseSchemaFromFiles(q, adminClient, [
         'src/fauna/resources/faunauth/collections/anomalies.fql',
         'src/fauna/resources/faunauth/collections/dinos.fql',
         'src/fauna/resources/faunauth/collections/User.fql',

--- a/tests/fauna/refresh.test.ts
+++ b/tests/fauna/refresh.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     destroyTestDatabase,
     getClient,
@@ -55,7 +54,7 @@ const setUp: SetUp = async testName => {
 
     const adminClient = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, adminClient, [
+    await populateDatabaseSchemaFromFiles(q, adminClient, [
         'src/fauna/resources/faunauth/collections/anomalies.fql',
         'src/fauna/resources/faunauth/collections/dinos.fql',
         'src/fauna/resources/faunauth/collections/User.fql',

--- a/tests/fauna/register.test.ts
+++ b/tests/fauna/register.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     destroyTestDatabase,
     setupTestDatabase,
@@ -28,7 +27,7 @@ const setUp: SetUp = async testName => {
     context.databaseClients = await setupTestDatabase(fauna, testName);
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/createEmailConfirmationToken.js',
         'src/fauna/resources/faunauth/functions/login.js',

--- a/tests/fauna/sample-auth-flow.test.ts
+++ b/tests/fauna/sample-auth-flow.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     destroyTestDatabase,
     setupTestDatabase,
@@ -29,7 +28,7 @@ const setUp: SetUp = async testName => {
     const databaseClients = await setupTestDatabase(fauna, testName);
     const adminClient = databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, adminClient, [
+    await populateDatabaseSchemaFromFiles(q, adminClient, [
         'src/fauna/resources/faunauth/collections/anomalies.fql',
         'src/fauna/resources/faunauth/collections/dinos.fql',
         'src/fauna/resources/faunauth/collections/User.fql',

--- a/tests/fauna/setPassword.test.ts
+++ b/tests/fauna/setPassword.test.ts
@@ -1,5 +1,4 @@
 import fauna from 'faunadb';
-import * as schemaMigrate from '@fauna-labs/fauna-schema-migrate';
 import {
     destroyTestDatabase,
     setupTestDatabase,
@@ -28,7 +27,7 @@ const setUp: SetUp = async testName => {
 
     const client = context.databaseClients.childClient;
 
-    await populateDatabaseSchemaFromFiles(schemaMigrate, q, client, [
+    await populateDatabaseSchemaFromFiles(q, client, [
         'src/fauna/resources/faunauth/collections/User.fql',
         'src/fauna/resources/faunauth/functions/createEmailConfirmationToken.js',
         'src/fauna/resources/faunauth/functions/login.js',


### PR DESCRIPTION
- avoid using `import * as` syntax; might fix the `JavaScript heap out of memory` bug in CI unit tests